### PR TITLE
Add malware-safe-chain workflow

### DIFF
--- a/.github/workflows/malware-safe-chain.yml
+++ b/.github/workflows/malware-safe-chain.yml
@@ -1,0 +1,25 @@
+name: Malware Safe Chain
+
+on:
+  pull_request: ~
+  push:
+    branches:
+      - main
+
+jobs:
+  malware-safe-chain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install safe-chain
+        run: curl -fsSL https://raw.githubusercontent.com/AikidoSec/safe-chain/main/install-scripts/install-safe-chain.sh | sh -s -- --ci
+
+      - name: Install dependencies with Safe Chain protection
+        run: pnpm install --frozen-lockfile

--- a/.github/workflows/malware-safe-chain.yml
+++ b/.github/workflows/malware-safe-chain.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
This PR adds the malware-safe-chain workflow to protect against malicious npm packages during CI/CD, as recommended by the [safe-chain repository](https://github.com/AikidoSec/safe-chain).